### PR TITLE
纠正表述不清和默认配置文件的错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ add_api_key - 增加 Api key
       ],
       "limit": 70,
       "speaker": {
-        "chinese": "zh-CN-XiaoxiaoNeural"
+        "ZH": "zh-CN-XiaoxiaoNeural"
       },
       "location": "japanwest"
     }
@@ -348,7 +348,7 @@ apt-get install ffmpeg
 - status 开关
 - type 类型
 
-Azure/Vits 语言类型代码均为二位大写缩写字母。
+Azure/Vits 的 `speaker` 语言类型代码均为二位大写缩写字母，例： `ZH`。
 
 **Azure 支持说明**
 


### PR DESCRIPTION
在“配置 service.json”中的默认文件示例，有关 Azure TTS 的部分有误导性内容，其中的语言 "chinese" 应该为 "ZH"
“语言类型代码”一词表述不清，无法找到相应的配置文件，容易误读为“type”导致错误配置